### PR TITLE
Corrected references in kustomization.yaml files

### DIFF
--- a/katalog/istio/kiali/kustomization.yaml
+++ b/katalog/istio/kiali/kustomization.yaml
@@ -1,5 +1,7 @@
 namespace: istio-system
 
+bases:
+  - configuration/
+
 resources:
   - kiali.yml
-  - configuration/

--- a/katalog/istio/sidecar-injection/configuration/sidecar-injection-and-egress/kustomization.yaml
+++ b/katalog/istio/sidecar-injection/configuration/sidecar-injection-and-egress/kustomization.yaml
@@ -1,6 +1,6 @@
 namespace: istio-system
 
-resources:
+bases:
   - ../base
 
 patchesStrategicMerge:

--- a/katalog/istio/telemetry/kustomization.yaml
+++ b/katalog/istio/telemetry/kustomization.yaml
@@ -1,4 +1,4 @@
 namespace: istio-system
 
-resources:
+bases:
   - base


### PR DESCRIPTION
During Angel's Istio workshop I noticed some wrong references in kustomization.yaml files.

Some base folders were references as resoures.