### PR TITLE
Remove explicit version from Istio Operator CR

### DIFF
--- a/katalog/istio-operator/istio/patches/istio-images.yml
+++ b/katalog/istio-operator/istio/patches/istio-images.yml
@@ -6,4 +6,3 @@ metadata:
 spec:
   # This targets all images used by the operator: currently pilot and proxyv2
   hub: registry.sighup.io/fury/istio
-  tag: 1.9.5


### PR DESCRIPTION
The operator will handle the tag based on its own version.
I.E. if using the image operator:1.XX.YY, the other images will inherit the same tag, like pilot:1.XX.YY

That's particularly useful in upgrade scenarios, where does not make sense to bring up a _new_ IstioOperator resource with the _old_ version, since the operator will restart pods anyway.