### PR TITLE
updated Jaeger query config

### DIFF
--- a/katalog/istio-operator/jaeger/jaeger.yml
+++ b/katalog/istio-operator/jaeger/jaeger.yml
@@ -21,8 +21,7 @@ spec:
         cpu: 100m
         memory: 128Mi
   query:
-    minReplicas: 2
-    maxReplicas: 5
+    replicas: 2
   ui:
     options:
       dependencies:


### PR DESCRIPTION
as per definition:

kubectl explain Jaeger.spec.query
KIND:     Jaeger
VERSION:  jaegertracing.io/v1
RESOURCE: query <Object>
FIELDS:
   ...
   replicas     <integer>
   ...