### PR TITLE
feat: prepare for release v1.2.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,13 +53,16 @@ steps:
     commands:
       - kustomize build katalog/istio-operator/profiles/full > isito-operator-full.yml
 
-  - name: deprek8ion
-    image: eu.gcr.io/swade1987/deprek8ion:1.1.35
+  - name: check-deprecated-apis
+    image: us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
     pull: always
     depends_on:
       - render
     commands:
-      - /conftest test -p /policies isito-operator-full.yml
+      # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
+      - /pluto detect isito-operator-full.yml --ignore-deprecations --target-versions=k8s=v1.21.0,istio=v1.12.6
+      # adding preemtive check for Kubernetes 1.24 without blockin the CI to have a list of unspported APIs in use.
+      - /pluto detect isito-operator-full.yml --ignore-deprecations  --ignore-removals --target-versions=k8s=v1.24.0,istio=v1.12.6
 
 ---
 name: e2e-kubernetes-1.20

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/github/v/release/sighupio/fury-kubernetes-service-mesh?label=Latest%20Release)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.2.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-service-mesh?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -50,8 +50,8 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 | --------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [furyctl][furyctl-repo]                 | `>=0.6.0`  | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
 | [kustomize][kustomize-repo]             | `>=3.9.1`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
-| [KFD Monitoring Module][kfd-monitoring] | `>=1.10.2` | To have functioning metrics, dashboards and alerts. Prometheus Operator is also required by Kiali.                                                             |
-| [KFD Logging Module][kfd-logging]       | `>=1.6.0`  | When using tracing, ElasticSearch / OpenSearch is used as storage.                                                                                             |
+| [KFD Monitoring Module][kfd-monitoring] | `>=1.11.1` | To have functioning metrics, dashboards and alerts. Prometheus Operator is also required by Kiali.                                                             |
+| [KFD Logging Module][kfd-logging]       | `>=1.7.1`  | When using tracing, ElasticSearch / OpenSearch is used as storage.                                                                                             |
 
 ### Deployment
 
@@ -60,7 +60,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
     - name: service-mesh/istio-operator
-      version: v1.1.0
+      version: v1.2.0
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -146,7 +146,7 @@ Before contributing, please read first the [Contributing Guidelines](docs/CONTRI
 
 ### Reporting Issues
 
-In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/fury-kubernetes-service-mesh/issues/new/choose).
+In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/fury-kubernetes-service-mesh/issues/new/choose).
 
 ## License
 

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -7,6 +7,7 @@
 | v1.0.0                              |               |               |               | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v1.0.1                              |               |               |               | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v1.1.0                              |               |               |               | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v1.2.0                              |               |               |               | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -2,9 +2,9 @@
 
 Welcome to the latest release of `service-mesh` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
-This is a minor release that includes:
+This is a minor release that:
 
-- Update Kiali's version to align it with the module's current Istio version.
+- Updates Kiali to version 1.44.0.
 - Improves the monitoring features of the module adding Prometheus Rules for alerting and Grafana Dashboards for visualizing metrics.
 
 ## Upgrade procedure
@@ -23,7 +23,7 @@ bases:
 furyctl vendor -H
 ```
 
-3. Build your desired profile kustomize base and apply it to the cluster, for example for the `minimal` profile run:
+3. Build your desired profile Kustomize base and apply it to the cluster, for example for the `minimal` profile run:
 
 ```bash
 kustomize build /vendor/katalog/service-mesh/istio-operator/profiles/minimal | kubectl apply -f

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -1,0 +1,30 @@
+# Service Mesh add-on module release 1.2.0
+
+Welcome to the latest release of `service-mesh` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This is a minor release that includes:
+
+- Update Kiali's version to align it with the module's current Istio version.
+- Improves the monitoring features of the module adding Prometheus Rules for alerting and Grafana Dashboards for visualizing metrics.
+
+## Upgrade procedure
+
+1. Update the version in your `Furyfile.yml` file:
+
+```yaml
+bases:
+    - name: service-mesh/istio-operator
+      version: v1.2.0
+```
+
+2. Download the module:
+
+```bash
+furyctl vendor -H
+```
+
+3. Build your desired profile kustomize base and apply it to the cluster, for example for the `minimal` profile run:
+
+```bash
+kustomize build /vendor/katalog/service-mesh/istio-operator/profiles/minimal | kubectl apply -f
+```

--- a/katalog/istio-operator/MAINTENANCE.md
+++ b/katalog/istio-operator/MAINTENANCE.md
@@ -60,7 +60,9 @@ To export the list of alerts from the YAML file to include them in the readme yo
 yq e '.spec.groups[] | .rules[] |  "| " + .alert + " | " + (.annotations.summary // "-" | sub("\n",". "))+ " | " + (.annotations.description // "-" | sub("\n",". ")) + " |"' katalog/istio-operator/istio/rules.yml
 ```
 
-## Kiali
+## Addons
+
+### Kiali
 
 To update Kiali, follow the next steps:
 
@@ -80,6 +82,10 @@ kubernetes-split-yaml kiali.yaml
 3. Delete the `kiali-tmp` directory
 
 Don't forget to sync the new images to our registry if needed.
+
+Customizations:
+
+- The port name for the service has been changed to `http`, as it was in previous versions to not break ingresses definitions in customers' installations. In the future, we should align with upstream and add a notice to the release notes.
 
 ## Links
 

--- a/katalog/istio-operator/README.md
+++ b/katalog/istio-operator/README.md
@@ -1,11 +1,11 @@
 # Istio Operator Package
 
-## For mTLS with nginx
+## For mTLS with NGINX
 
-### Ingress Controller Nginx
+### Ingress Controller NGINX
 
 1. label the ingress-nginx with the `istio-injection=enabled`
-2. crete the following crd:
+2. crete the following CRD:
 
 ```yaml
 apiVersion: "security.istio.io/v1beta1"
@@ -27,7 +27,7 @@ annotations:
 
 ### Microservice with mTLS strict
 
-1. in the namespace of your applications just put this crd:
+1. in the namespace of your applications just put this CRD:
 
 ```yaml
 apiVersion: "security.istio.io/v1beta1"
@@ -47,15 +47,15 @@ nginx.ingress.kubernetes.io/service-upstream: "true"
 nginx.ingress.kubernetes.io/upstream-vhost: productpage.test.svc.cluster.local
 ```
 
-This will enable the traffic from the ingress to a service deployed in a namespace with a mTLS in STRICT mode
+This will enable the traffic from the ingress to a service deployed in a namespace with mTLS in STRICT mode.
 
-### Enable Tracing for application using nginx ingress controller
+### Enable Tracing for application using NGINX ingress controller
 
-Is pretty tricky to preserve both ingress nginx functionality and in the same keep of Istio tracing advantages, but somehow is possible to do that.
+Is pretty tricky to preserve both ingress NGINX functionality and in the same keep of Istio tracing advantages, but somehow is possible to do that.
 
-Given the application "hello" in a namaspace "test", you have to do the following stuff:
+Given the application "hello" in a namespace "test", you have to do the following stuff:
 
-1. create virtualservice for your app
+1. create `VirtualService` for your app
 
 ```yaml
 apiVersion: networking.istio.io/v1beta1
@@ -103,7 +103,7 @@ spec:
       name: v1
 ```
 
-3. create an external service that point to the ingressGateway Service (that is deployed in a separate ns):
+3. create an external service that points to the `ingressGateway` Service (that is deployed in a separate ns):
 
 ```yaml
 kind: Service

--- a/katalog/tests/istio-operator/citadel/mtls-at-bar-httpbin-service.yaml
+++ b/katalog/tests/istio-operator/citadel/mtls-at-bar-httpbin-service.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-apiVersion: "authentication.istio.io/v1alpha1"
+apiVersion: "authentication.istio.io/v1beta1"
 kind: "Policy"
 metadata:
   name: "httpbin"


### PR DESCRIPTION
- update docs for releasing 1.2.0 (readme, comp matrix, release notes)
- fix the requirements versions in readme with the ones used in tests
- update CI with pluto instead of deprek8n to check for deprecated API versions usage
- improve wording and style in readmes
- update test that was using a deprecated API version