### PR TITLE
Feature/update kiali to v1440

### DIFF
--- a/katalog/istio-operator/kiali/cluster-role-binding.yml
+++ b/katalog/istio-operator/kiali/cluster-role-binding.yml
@@ -4,15 +4,14 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-# This cluster role binding allows anyone in the "manager" group to read secrets in any namespace.
 kind: ClusterRoleBinding
 metadata:
   name: kiali
-subjects:
-  - kind: ServiceAccount
-    name: kiali # Name is case sensitive
-    apiGroup: ""
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kiali
-  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: kiali
+  namespace: istio-system

--- a/katalog/istio-operator/kiali/config/config.yaml
+++ b/katalog/istio-operator/kiali/config/config.yaml
@@ -2,11 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-istio_component_namespaces:
-  grafana: monitoring
-  tracing: istio-system
-  prometheus: monitoring
-istio_namespace: istio-system
 auth:
   strategy: "anonymous"
 deployment:
@@ -16,9 +11,13 @@ deployment:
 api:
   namespaces:
     exclude:
-      - kube-public
-      - kube-system
-      - kube-node-lease
+      - "^kube-.*"
+kiali_feature_flags:
+  certificates_information_indicators:
+    enabled: true
+    secrets:
+    - cacerts
+    - istio-ca-secret
 login_token:
   signing_key: "eto6tUSMft"
 server:

--- a/katalog/istio-operator/kiali/deployment.yml
+++ b/katalog/istio-operator/kiali/deployment.yml
@@ -25,7 +25,7 @@ spec:
     spec:
       serviceAccountName: kiali
       containers:
-        - image: "quay.io/kiali/kiali:v1.42"
+        - image: "quay.io/kiali/kiali"
           imagePullPolicy: IfNotPresent
           name: kiali
           command:

--- a/katalog/istio-operator/kiali/kustomization.yaml
+++ b/katalog/istio-operator/kiali/kustomization.yaml
@@ -25,7 +25,7 @@ configMapGenerator:
     files:
       - config/config.yaml
 
-secretGenerator:
-  - name: kiali
-    envs:
-      - secrets/kiali-auth.env
+images:
+  - name: quay.io/kiali/kiali
+    newName: registry.sighup.io/fury/kiali/kiali
+    newTag: v1.44.0

--- a/katalog/istio-operator/kiali/secrets/kiali-auth.env
+++ b/katalog/istio-operator/kiali/secrets/kiali-auth.env
@@ -1,2 +1,0 @@
-passphrase=admin
-username=admin

--- a/katalog/istio-operator/kiali/service.yml
+++ b/katalog/istio-operator/kiali/service.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: http
+  - name: http-kiali
     protocol: TCP
     port: 20001
   - name: http-metrics


### PR DESCRIPTION
I updated the Kiali image and related configurations with version 1.44.0.
Tests were performed using Kubernetes version 1.20.15.
Here is a note I encountered while testing Kiali:
- the new version of the module (taken from the master branch), has a change from the previous version (v1.1.0). That is, change the name of the port used by Kiali: from http-kiali to http. This could have an impact on ingresses already present on the system.